### PR TITLE
Pass parameters from config to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Configure the plugin in your openvpn config, passing the path to the external sc
 
     plugin /path/to/auth_script.so /path/to/external/script.sh
 
+If your script needs aditional arguments you can put them after script path and they will get passed to the script:
+
+    plugin /path/to/auth_script.so /path/to/external/script.sh arg1 arg2
+
 ## External Script requirements
 
 The script used to handle authentication has a very specific set of skills it needs, and if you don't provide those it will hunt you down in silence.


### PR DESCRIPTION
I've updated the plugin so now it can pass plugin parameters from openvpn config to script.

I did this because before my `script.sh` looked like this:
```sh
#!/bin/sh

/etc/openvpn/go-authy-vpn <api key> authy-vpn.conf
```

and with this modification I don't need `script.sh` anymore and can just have this in the config:

```
plugin /etc/openvpn/auth_script.so /etc/openvpn/go-authy-vpn <api key> authy-vpn.conf
```
