### PR TITLE
Freebsd Compilation Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,22 @@ CFLAGS ?= -O -Wall -Wextra -Wformat-security -fstack-protector-strong -D_FORTIFY
 CFLAGS += -std=c99 -D_POSIX_C_SOURCE=200809L
 LDFLAGS += -fPIC -shared
 
+# FreeBSD puts the openvpn header in a different location unknown to clang
+IPATH_FREEBSD = /usr/local/include/
+
+# Add OS Specific build flags
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+	# Add the include path for openvpn-plugin.h
+	CFLAGS += -I$(IPATH_FREEBSD) 
+	# Ensure the signals we need are visible
+	CFLAGS += -D_XOPEN_SOURCE=600
+endif
+
 all: plugin
 
 plugin: auth_script.c
+	$(info Building for $(UNAME_S))
 	$(CC) $(CFLAGS) $(LDFLAGS) -o auth_script.so auth_script.c
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= cc
-CFLAGS ?= -O -Wall -Wextra -Wformat-security -fstack-protector-strong -D_FORTIFY_SOURCE=2
+CFLAGS ?= -O -Wall -Wextra -Wformat-security -D_FORTIFY_SOURCE=2
 CFLAGS += -std=c99 -D_POSIX_C_SOURCE=200809L
 LDFLAGS += -fPIC -shared
 
@@ -13,6 +13,14 @@ ifeq ($(UNAME_S),FreeBSD)
 	CFLAGS += -I$(IPATH_FREEBSD) 
 	# Ensure the signals we need are visible
 	CFLAGS += -D_XOPEN_SOURCE=600
+	
+	# BSD uses Clang - we need to check for stack-protector-strong flag 
+	STACK_PROTECT := $(shell $(CC) --help | grep stack-protector-strong)
+	ifneq ($(filter %stack-protector-strong, $(STACK_PROTECT)),)
+		CFLAGS += -fstack-protector-strong 
+	endif
+else
+	CFLAGS += -fstack-protector-strong
 endif
 
 all: plugin


### PR DESCRIPTION
I'm working on implementing this plugin/workaround for multi-factor authentication in a FreeBSD environment and I found that the provided make file didn't work as expected. 

This change simply adds additional compilation flags and missing library paths such that gmake can succesfully build the package in a FreeBSD environment.