### PR TITLE
Fix: Building auth-script-openvpn plugin on ubuntu based systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [ push, pull_request ]
 jobs:
   ubuntu_trusty:
     runs-on: ubuntu-latest
-    name: Test building for ubuntu trust
+    name: Test building for ubuntu trusty
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test build for common used environments
+on: [ push, pull_request ]
+jobs:
+  ubuntu_trusty:
+    runs-on: ubuntu-latest
+    name: Test building for ubuntu trust
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: build
+        run: docker build -f test/build.Dockerfile --build-arg TAG=trusty -t test:test .
+
+  ubuntu_bionic:
+    runs-on: ubuntu-latest
+    name: Test building for ubuntu bionic
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: build
+        run: docker build -f test/build.Dockerfile --build-arg TAG=bionic -t test:test .
+

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,18 @@ else
 	endif
 endif
 
-$(info Building for $(UNAME_S))
+# Detect Ubuntu to be able to include a different openvpn header file
+LSB_RELEASE_BIN := $(shell command -v lsb_release 2> /dev/null)
+ifndef LSB_RELEASE_BIN
+$(warning lsb_release is not available on the system, skipping OS detection)
+else
+	ifneq ($(findstring UBUNTU, $(shell lsb_release -si)),)
+		CFLAGS += -DOS_UBUNTU
+	endif
+endif
+
+
+$(info Building 4 for $(UNAME_S))
 
 # Output Files
 SRC 	= $(wildcard *.c)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifeq ($(UNAME_S),FreeBSD)
 	endif
 else
 	STACK_PROTECT := $(shell $(CC) -dumpspecs | grep stack-protector-strong)
-	ifneq ($(filter %stack-protector-strong, $(STACK_PROTECT)),)
+	ifneq ($(findstring fstack-protector-strong, $(STACK_PROTECT)),)
 		CFLAGS += -fstack-protector-strong
 	endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ ifeq ($(UNAME_S),FreeBSD)
 		CFLAGS += -fstack-protector-strong 
 	endif
 else
-	CFLAGS += -fstack-protector-strong
+	STACK_PROTECT := $(shell $(CC) -dumpspecs | grep stack-protector-strong)
+	ifneq ($(filter %stack-protector-strong, $(STACK_PROTECT)),)
+		CFLAGS += -fstack-protector-strong
+	endif
 endif
 
 $(info Building for $(UNAME_S))

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LSB_RELEASE_BIN := $(shell command -v lsb_release 2> /dev/null)
 ifndef LSB_RELEASE_BIN
 $(warning lsb_release is not available on the system, skipping OS detection)
 else
-	ifneq ($(findstring UBUNTU, $(shell lsb_release -si)),)
+	ifneq ($(findstring Ubuntu, $(shell lsb_release -si)),)
 		CFLAGS += -DOS_UBUNTU
 	endif
 endif

--- a/openvpn-plugin-auth-script.c
+++ b/openvpn-plugin-auth-script.c
@@ -17,13 +17,18 @@
 /********** Includes */
 #include <stddef.h>
 #include <errno.h>
-#include <openvpn-plugin.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+
+#ifdef OS_UBUNTU
+#include <openvpn/openvpn-plugin.h>
+#else
+#include <openvpn-plugin.h>
+#endif
 
 /********** Constants */
 /* For consistency in log messages */

--- a/test/build.Dockerfile
+++ b/test/build.Dockerfile
@@ -1,0 +1,16 @@
+ARG DISTRIBUTION=ubuntu
+ARG TAG=bionic
+FROM $DISTRIBUTION:$TAG
+
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+  lsb-release \
+  openvpn \
+  build-essential
+
+RUN mkdir -p /opt/vpnauth
+WORKDIR /opt/vpnauth
+COPY . /opt/vpnauth
+
+RUN make


### PR DESCRIPTION
## Motivation

We are currently using Ubuntu/Debian based systems and would like this plugin to work for both of them

## Description

The pull request introduces the following changes:
- detect if `fstack-protector-strong` is available in the environment - default gcc on ubuntu 14.04 
- detect if the OS is ubuntu based and include `openvpn/openvpn-plugin.h` instead of `openvpn-plugin.h`

For testing docker was used and a simple github action has been added to compile the extension both on ubuntu14.04 and 18.04

This does not include any functional tests of the plugin 
